### PR TITLE
允许不安全的请求

### DIFF
--- a/m3u8-downloader.go
+++ b/m3u8-downloader.go
@@ -36,7 +36,7 @@ var (
 	htFlag  = flag.String("ht", "apiv1", "设置getHost的方式(apiv1: `http(s):// + url.Host + path.Dir(url.Path)`; apiv2: `http(s)://+ u.Host`")
 	oFlag   = flag.String("o", "output", "自定义文件名(默认为output)")
 	cFlag   = flag.String("c", "", "自定义请求cookie")
-	sFlag   = flag.Bool("s", false, "是否允许不安全的请求(默认为false)")
+	sFlag   = flag.Int("s", 0, "是否允许不安全的请求(默认为0)")
 
 	logger *log.Logger
 	ro     = &grequests.RequestOptions{
@@ -80,7 +80,9 @@ func Run() {
 	cookie := *cFlag
 	insecure := *sFlag
 
-	ro.InsecureSkipVerify = insecure
+	if insecure != 0 {
+		ro.InsecureSkipVerify = true
+	}
 
 	//http自定义cookie
 	if cookie != "" {

--- a/m3u8-downloader.go
+++ b/m3u8-downloader.go
@@ -36,6 +36,7 @@ var (
 	htFlag  = flag.String("ht", "apiv1", "设置getHost的方式(apiv1: `http(s):// + url.Host + path.Dir(url.Path)`; apiv2: `http(s)://+ u.Host`")
 	oFlag   = flag.String("o", "output", "自定义文件名(默认为output)")
 	cFlag   = flag.String("c", "", "自定义请求cookie")
+	sFlag   = flag.Bool("s", false, "是否允许不安全的请求(默认为false)")
 
 	logger *log.Logger
 	ro     = &grequests.RequestOptions{
@@ -77,6 +78,9 @@ func Run() {
 	hostType := *htFlag
 	movieDir := *oFlag
 	cookie := *cFlag
+	insecure := *sFlag
+
+	ro.InsecureSkipVerify = insecure
 
 	//http自定义cookie
 	if cookie != "" {


### PR DESCRIPTION
增加了 -s 选项：因为代理问题或者其他原因，在可信任环境中允许非法证书。