### PR TITLE
处理部分情况下获取不到m3u8地址的问题

### DIFF
--- a/m3u8-downloader.go
+++ b/m3u8-downloader.go
@@ -142,7 +142,7 @@ func getHost(Url, ht string) (host string) {
 	checkErr(err)
 	switch ht {
 	case "apiv1":
-		host = u.Scheme + "://" + u.Host + path.Dir(u.RawPath)
+		host = u.Scheme + "://" + u.Host + path.Dir(u.EscapedPath())
 	case "apiv2":
 		host = u.Scheme + "://" + u.Host
 	}


### PR DESCRIPTION
https://stackoverflow.com/questions/39270633/why-does-url-parse-not-populate-url-rawpath