### PR TITLE
拼接URL时，如果/开头，则去掉前缀

### DIFF
--- a/m3u8-downloader.go
+++ b/m3u8-downloader.go
@@ -200,6 +200,7 @@ func getTsList(host, body string) (tsList []TsInfo) {
 				}
 				tsList = append(tsList, ts)
 			} else {
+				line = strings.TrimPrefix(line, "/")
 				ts = TsInfo{
 					Name: fmt.Sprintf(TS_NAME_TEMPLATE, index),
 					Url:  fmt.Sprintf("%s/%s", host, line),


### PR DESCRIPTION
部分网站验证URL时 https://domain.com//abc.ts 会返回错误信息，https://domain.com/abc.ts 才能正确下载文件